### PR TITLE
Modify pure pursuit parameters

### DIFF
--- a/ros/src/waypoint_follower/include/pure_pursuit_core.h
+++ b/ros/src/waypoint_follower/include/pure_pursuit_core.h
@@ -96,7 +96,7 @@ public:
     , param_flag_(0)
     , const_lookahead_distance_(4.0)
     , initial_velocity_(5.0)
-    , lookahead_distance_calc_ratio_(2.0)
+    , lookahead_distance_calc_ratio_(1.7)
     , minimum_lookahead_distance_(6.0)
     , displacement_threshold_(0.2)
     , relative_angle_threshold_(5.)

--- a/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
@@ -317,7 +317,7 @@ geometry_msgs::TwistStamped PurePursuit::outputZero() const
 }
 geometry_msgs::TwistStamped PurePursuit::outputTwist(geometry_msgs::Twist t) const
 {
-  double g_lateral_accel_limit = 5.0;
+  double g_lateral_accel_limit = 1.5;
   double ERROR = 1e-8;
 
   geometry_msgs::TwistStamped twist;


### PR DESCRIPTION
@cfezequiel @hurtadosanti 

In order to track the reference path, I tuned some parameters for pure-pursuit algorithm


1.  ```lookahead_distance_calc_ratio_ ``` 2.0 to 1.7
Look-ahead-distance should be set short if the vehicle needs to quickly return on the route. However, if it is set too short, there is a risk of lateral oscillation. 
So, I reduced ```lookahead_distance_calc_ratio_ ``` 2.0 to 1.7 to track the reference path more fast.

2. ```g_lateral_accel_limit``` 5.0 to 1.5
g_lateral_accel_limit is lateral acceleration for drivers. However, previous value 5.0[m/s^2] was too high. If ```g_lateral_accel_limit``` is too high, the car doesn't reduce the speed on the curve.
Therefore, in order to adapt on the curve properly, I reduce the parameter as 1.5.

Now, the car is on the center of the lane without lane departure